### PR TITLE
Allow any hashable type to be the name of a Vertex

### DIFF
--- a/depdag.py
+++ b/depdag.py
@@ -117,6 +117,9 @@ class VerticesMap:
     @property
     def dag(self):
         return self._dag
+     
+    def __contains__(self, item):
+        return item in self._vertices
 
     def __len__(self):
         return len(self._vertices)

--- a/depdag.py
+++ b/depdag.py
@@ -57,9 +57,9 @@ __version_tuple__ = (0, 2, 0)
 __version__ = '.'.join(map(str, __version_tuple__))
 
 from collections import OrderedDict
-from typing import List, Dict, Iterable, Optional, Any
+from typing import List, Dict, Iterable, Optional, Any, Hashable
 
-VertexName = str
+VertexName = Hashable
 
 
 class Vertex:


### PR DESCRIPTION
```python
from kyc_decisioning.kyc_enums.backend_event import BackEndEvent

vert = DepDag().vertices
    vert[BackEndEvent.applicant].depends_on(BackEndEvent.business)
    vert[BackEndEvent.business].depends_on(BackEndEvent.installation)

    assert not vert.dag.is_cyclic()
    for v in vert.all():
        print("- vert", v.name, "-> all supporters:", v.supporters(recurse=True))
```
---
```

- vert BackEndEvent.applicant -> all supporters: [<BackEndEvent.business: 'business'>, <BackEndEvent.installation: 'installation'>]
- vert BackEndEvent.business -> all supporters: [<BackEndEvent.installation: 'installation'>]
- vert BackEndEvent.installation -> all supporters: []

```
