### PR TITLE
Implement fast fail on cycle (#13)

### DIFF
--- a/tests/performance.py
+++ b/tests/performance.py
@@ -1,0 +1,29 @@
+"""
+Create large DAGs and test is_cyclic() performance.
+"""
+
+from timeit import timeit
+from depdag import DepDag
+
+
+def create_large_dag(nodes=1000, fail_on_cycle=False):
+    dag = DepDag(fail_on_cycle=fail_on_cycle)
+    for idx in range(nodes//3):
+        name = f'node-{idx}'
+        dag.create(name)
+        dag[name].depends_on(name + '-one')
+        dag[name].depends_on(name + '-two')
+
+
+def perf_test():
+    size = 3000
+    no_cycle_check_time = timeit(lambda: create_large_dag(3000), number=1)
+    cycle_check_time = timeit(lambda: create_large_dag(3000, True), number=1)
+
+    print(f"{size}-vertices DepDag(fail_on_cycle=False):", no_cycle_check_time, 'sec.')
+    print(f"{size}-vertices DepDag(fail_on_cycle=True):", cycle_check_time, 'sec.')
+    print("Second is", cycle_check_time/no_cycle_check_time, "times slower.")
+
+
+if __name__ == '__main__':
+    perf_test()


### PR DESCRIPTION
Resolves #13.

The `fail_on_cycle` default is `False` on purpose:

Imagine a 1000 vertices graph -- the `DepDag::is_cyclic()` method works via an expensive recursive algorithm; in this case it will be invoked 999 times, and the last calls will be prohibitively expensive due to the many vertices.

There's a performance test in this branch, `tests/performance.py`; here's a sample output:

```
virtualenvs/depdag/bin/python3.7 {REPO_ROOT}/depdag/tests/performance.py
3000-vertices DepDag(fail_on_cycle=False): 0.010500976000002993 sec.
3000-vertices DepDag(fail_on_cycle=True): 3.546689527000126 sec.
Second is 337.74856041944247 times slower.
```